### PR TITLE
Switch RDS DB instance class from t2 to t3

### DIFF
--- a/modules/module-2/main.tf
+++ b/modules/module-2/main.tf
@@ -131,7 +131,7 @@ resource "aws_security_group" "database-security-group" {
 resource "aws_db_instance" "database-instance" {
   identifier             = "aws-goat-db"
   allocated_storage      = 10
-  instance_class         = "db.t2.micro"
+  instance_class         = "db.t3.micro"
   engine                 = "mysql"
   engine_version         = "5.7"
   username               = "root"


### PR DESCRIPTION
Fix for #57 
The t2 instance class has been discontinued for RDS instances, using t3 instead, also available under free tier.