### PR TITLE
Update GitHub workflows and migrate to launch templates from launch configurations

### DIFF
--- a/.github/workflows/tf-apply-main.yml
+++ b/.github/workflows/tf-apply-main.yml
@@ -30,23 +30,23 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
-    
+      uses: actions/checkout@v4
+
     - name: Set up Terraform
       uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: 1.5.0  # Replace with the required version
-    
+        terraform_version: 1.10.5
+
     - name: Set Account ID
       id: account
       run: |
-        echo "::set-output name=ACCOUNT_ID::$(aws sts get-caller-identity --query Account --output text)"
+        echo "ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)" >> $GITHUB_ENV
 
     - name: Check previous AWSGoat Deployment
       id: check 
       run: |
-        echo $ACCOUNT_ID
-        aws s3api head-object --bucket do-not-delete-awsgoat-state-files-${{ steps.account.outputs.ACCOUNT_ID }} --key terraform.tfstate
+        echo ${{ env.ACCOUNT_ID }}
+        aws s3api head-object --bucket do-not-delete-awsgoat-state-files-${{ env.ACCOUNT_ID }} --key terraform.tfstate
       continue-on-error: true
 
     - name: Exit if previous deployment exists
@@ -62,7 +62,7 @@ jobs:
         terraform init 
         
     # Installs boto3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: 3
     - name: install
@@ -91,7 +91,7 @@ jobs:
       if: always()
       run: |
         cd modules/${{ github.event.inputs.module }}
-        aws s3 cp ./terraform.tfstate s3://do-not-delete-awsgoat-state-files-${{ steps.account.outputs.ACCOUNT_ID }}/terraform.tfstate 
+        aws s3 cp ./terraform.tfstate s3://do-not-delete-awsgoat-state-files-${{ env.ACCOUNT_ID }}/terraform.tfstate 
 
     # Terraform Output the API Gateway url
     - name: Application URL

--- a/.github/workflows/tf-destroy-main.yml
+++ b/.github/workflows/tf-destroy-main.yml
@@ -32,23 +32,21 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-
-
     - name: Set up Terraform
       uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: 1.5.0  # Replace with the required version
+        terraform_version: 1.10.5
     
     - name: Set Account ID
       id: account
       run: |
-        echo "::set-output name=ACCOUNT_ID::$(aws sts get-caller-identity --query Account --output text)"
+        echo "ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)" >> $GITHUB_ENV
 
     # Copy and delete terraform.tfstate files from s3 bucket
     - name: Retrieve tfstate
       run: |
         cd modules/${{ github.event.inputs.module }}
-        aws s3 cp s3://do-not-delete-awsgoat-state-files-${{ steps.account.outputs.ACCOUNT_ID }}/terraform.tfstate ./terraform.tfstate
+        aws s3 cp s3://do-not-delete-awsgoat-state-files-${{ env.ACCOUNT_ID }}/terraform.tfstate ./terraform.tfstate
 
     # Initialize a new Terraform working directory
     - name: Terraform Init

--- a/.github/workflows/tf-destroy-main.yml
+++ b/.github/workflows/tf-destroy-main.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Terraform
       uses: hashicorp/setup-terraform@v2

--- a/modules/module-2/main.tf
+++ b/modules/module-2/main.tf
@@ -347,22 +347,32 @@ data "aws_ami" "ecs_optimized_ami" {
 }
 
 
+resource "aws_launch_template" "ecs_launch_template" {
+  name_prefix   = "ecs-launch-template-"
+  image_id      = data.aws_ami.ecs_optimized_ami.id
+  instance_type = "t2.micro"
 
-resource "aws_launch_configuration" "ecs_launch_config" {
-  image_id             = data.aws_ami.ecs_optimized_ami.id
-  iam_instance_profile = aws_iam_instance_profile.ecs-instance-profile.name
-  security_groups      = [aws_security_group.ecs_sg.id]
-  user_data            = data.template_file.user_data.rendered
-  instance_type        = "t2.micro"
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ecs-instance-profile.name
+  }
+
+  vpc_security_group_ids = [aws_security_group.ecs_sg.id]
+  user_data              = base64encode(data.template_file.user_data.rendered)
 }
+
 resource "aws_autoscaling_group" "ecs_asg" {
-  name                 = "ECS-lab-asg"
-  vpc_zone_identifier  = [aws_subnet.lab-subnet-public-1.id]
-  launch_configuration = aws_launch_configuration.ecs_launch_config.name
-  desired_capacity     = 1
-  min_size             = 0
-  max_size             = 1
+  name                = "ECS-lab-asg"
+  vpc_zone_identifier = [aws_subnet.lab-subnet-public-1.id]
+  desired_capacity    = 1
+  min_size            = 0
+  max_size            = 1
+
+  launch_template {
+    id      = aws_launch_template.ecs_launch_template.id
+    version = "$Latest"
+  }
 }
+
 
 resource "aws_ecs_cluster" "cluster" {
   name = "ecs-lab-cluster"


### PR DESCRIPTION
This PR includes updates to GitHub workflows and infrastructure configuration:

- GitHub Workflow Changes:
    - Updated Terraform version to the latest supported release.
    - Replaced `set-output` with **Github ENV**, as `set-output` is deprecated by **GitHub**.

- Infrastructure Changes:
    - Migrated from **Launch Configuration** to **Launch Template**, as AWS no longer supports Launch Configurations for new accounts, causing errors.

Addressing Issues #55 and #71 


