### PR TITLE
Fix S3 ACL Configuration 

### DIFF
--- a/modules/module-1/main.tf
+++ b/modules/module-1/main.tf
@@ -3230,6 +3230,8 @@ resource "aws_s3_bucket_acl" "bucket_upload" {
 resource "aws_s3_bucket_policy" "allow_access_for_prod" {
   bucket = aws_s3_bucket.bucket_upload.id
   policy = data.aws_iam_policy_document.allow_get_access.json
+
+  depends_on = [ aws_s3_bucket_acl.bucket_upload ]
 }
 data "aws_iam_policy_document" "allow_get_access" {
   statement {
@@ -3259,6 +3261,7 @@ resource "aws_s3_bucket_cors_configuration" "bucket_upload" {
     allowed_methods = ["GET", "POST", "PUT"]
     allowed_origins = ["*"]
   }
+  depends_on = [aws_s3_bucket_acl.bucket_upload]
 }
 # Upload in production bucket
 
@@ -3269,7 +3272,7 @@ resource "aws_s3_object" "upload_folder_prod" {
   acl          = "public-read"
   source       = "./resources/s3/webfiles/${each.value}"
   content_type = lookup(local.content_type_map, regex("\\.(?P<extension>[A-Za-z0-9]+)$", each.value).extension, "application/octet-stream")
-  depends_on   = [aws_s3_bucket.bucket_upload, null_resource.file_replacement_api_gw]
+  depends_on   = [aws_s3_bucket.bucket_upload, null_resource.file_replacement_api_gw, aws_s3_bucket_acl.bucket_upload]
 }
 
 
@@ -3314,6 +3317,8 @@ resource "aws_s3_bucket_acl" "dev" {
 resource "aws_s3_bucket_policy" "allow_access_for_dev" {
   bucket = aws_s3_bucket.dev.bucket
   policy = data.aws_iam_policy_document.allow_get_list_access.json
+
+  depends_on = [ aws_s3_bucket_acl.dev ]
 }
 data "aws_iam_policy_document" "allow_get_list_access" {
   statement {
@@ -3337,7 +3342,7 @@ resource "aws_s3_object" "upload_folder_dev" {
   acl          = "public-read"
   source       = "./resources/s3/webfiles/build/${each.value}"
   content_type = lookup(local.content_type_map, regex("\\.(?P<extension>[A-Za-z0-9]+)$", each.value).extension, "application/octet-stream")
-  depends_on   = [aws_s3_bucket.dev, null_resource.file_replacement_ec2_ip]
+  depends_on   = [aws_s3_bucket.dev, null_resource.file_replacement_ec2_ip, aws_s3_bucket_acl.dev]
 }
 
 resource "aws_s3_object" "upload_folder_dev_2" {
@@ -3347,7 +3352,7 @@ resource "aws_s3_object" "upload_folder_dev_2" {
   acl          = "public-read"
   source       = "./resources/s3/shared/${each.value}"
   content_type = lookup(local.content_type_map, regex("\\.(?P<extension>[A-Za-z0-9]+)$", each.value).extension, "application/octet-stream")
-  depends_on   = [aws_s3_bucket.dev, null_resource.file_replacement_ec2_ip]
+  depends_on   = [aws_s3_bucket.dev, null_resource.file_replacement_ec2_ip, aws_s3_bucket_acl.dev]
 }
 
 
@@ -3398,7 +3403,7 @@ resource "aws_s3_object" "upload_temp_object" {
   key          = each.value
   source       = "./resources/s3/webfiles/build/${each.value}"
   content_type = lookup(local.content_type_map, regex("\\.(?P<extension>[A-Za-z0-9]+)$", each.value).extension, "application/octet-stream")
-  depends_on   = [aws_s3_bucket.bucket_upload, null_resource.file_replacement_lambda_react]
+  depends_on   = [aws_s3_bucket.bucket_upload, null_resource.file_replacement_lambda_react, aws_s3_bucket_acl.bucket_temp]
 }
 
 resource "aws_s3_object" "upload_temp_object_2" {
@@ -3408,7 +3413,7 @@ resource "aws_s3_object" "upload_temp_object_2" {
   key          = each.value
   source       = "./resources/s3/shared/${each.value}"
   content_type = lookup(local.content_type_map, regex("\\.(?P<extension>[A-Za-z0-9]+)$", each.value).extension, "application/octet-stream")
-  depends_on   = [aws_s3_bucket.bucket_upload, null_resource.file_replacement_lambda_react]
+  depends_on   = [aws_s3_bucket.bucket_upload, null_resource.file_replacement_lambda_react, aws_s3_bucket_acl.bucket_temp]
 }
 /* Creating a S3 Bucket for Terraform state file upload. */
 resource "aws_s3_bucket" "bucket_tf_files" {


### PR DESCRIPTION
### This PR includes updates to module-1 terraform file `main.tf`

The issue being addressed was related to S3 bucket ACL permissions not being applied in time during the deployment process. Specifically, objects were being trying to upload to the S3 bucket before the ACL configuration was fully attached, resulting in the following error

```
api error AccessControlListNotSupported: The bucket does not allow ACLs
```

### Fix

The fix ensures that the object upload operation occurs only after the bucket ACL has been properly attached. This was achieved by restructuring the deployment logic to enforce the correct resource creation order using depends_on, thereby preventing race conditions and ensuring consistent, error-free uploads.


