### PR TITLE
Replace deprecated template provider for Apple Silicon support

### DIFF
--- a/modules/module-1/main.tf
+++ b/modules/module-1/main.tf
@@ -3574,12 +3574,10 @@ resource "aws_iam_policy" "goat_inline_policy_2" {
   })
 }
 
-data "template_file" "goat_script" {
-  template = file("resources/ec2/goat_user_data.tpl")
-  vars = {
+locals {
+  goat_script = templatefile("resources/ec2/goat_user_data.tpl", {
     S3_BUCKET_NAME = aws_s3_bucket.bucket_temp.bucket
-  }
-  depends_on = [aws_s3_bucket.bucket_temp]
+  })
 }
 
 
@@ -3605,7 +3603,7 @@ resource "aws_instance" "goat_instance" {
   tags = {
     Name = "AWS_GOAT_DEV_INSTANCE"
   }
-  user_data = data.template_file.goat_script.rendered
+  user_data = local.goat_script
   depends_on = [
     aws_s3_object.upload_temp_object_2
   ]

--- a/modules/module-2/main.tf
+++ b/modules/module-2/main.tf
@@ -479,8 +479,8 @@ resource "null_resource" "rds_endpoint" {
   provisioner "local-exec" {
     command     = <<EOF
 RDS_URL="${aws_db_instance.database-instance.endpoint}"
-RDS_URL=$${RDS_URL::-5}
-sed -i "s,RDS_ENDPOINT_VALUE,$RDS_URL,g" ${path.module}/resources/ecs/task_definition.json
+RDS_URL=$${RDS_URL%:*}
+sed -i'' -e "s,RDS_ENDPOINT_VALUE,$RDS_URL,g" ${path.module}/resources/ecs/task_definition.json
 EOF
     interpreter = ["/bin/bash", "-c"]
   }
@@ -494,8 +494,8 @@ resource "null_resource" "cleanup" {
   provisioner "local-exec" {
     command     = <<EOF
 RDS_URL="${aws_db_instance.database-instance.endpoint}"
-RDS_URL=$${RDS_URL::-5}
-sed -i "s,$RDS_URL,RDS_ENDPOINT_VALUE,g" ${path.module}/resources/ecs/task_definition.json
+RDS_URL=$${RDS_URL%:*}
+sed -i'' -e "s,$RDS_URL,RDS_ENDPOINT_VALUE,g" ${path.module}/resources/ecs/task_definition.json
 EOF
     interpreter = ["/bin/bash", "-c"]
   }

--- a/modules/module-2/main.tf
+++ b/modules/module-2/main.tf
@@ -357,7 +357,7 @@ resource "aws_launch_template" "ecs_launch_template" {
   }
 
   vpc_security_group_ids = [aws_security_group.ecs_sg.id]
-  user_data              = base64encode(data.template_file.user_data.rendered)
+  user_data              = base64encode(local.user_data)
 }
 
 resource "aws_autoscaling_group" "ecs_asg" {
@@ -382,12 +382,13 @@ resource "aws_ecs_cluster" "cluster" {
   }
 }
 
-data "template_file" "user_data" {
-  template = file("${path.module}/resources/ecs/user_data.tpl")
+locals {
+  user_data            = file("${path.module}/resources/ecs/user_data.tpl")
+  task_definition_json = file("${path.module}/resources/ecs/task_definition.json")
 }
 
 resource "aws_ecs_task_definition" "task_definition" {
-  container_definitions    = data.template_file.task_definition_json.rendered
+  container_definitions    = local.task_definition_json
   family                   = "ECS-Lab-Task-definition"
   network_mode             = "bridge"
   memory                   = "512"
@@ -404,13 +405,6 @@ resource "aws_ecs_task_definition" "task_definition" {
     name      = "kernels"
     host_path = "/usr/src/kernels"
   }
-}
-
-data "template_file" "task_definition_json" {
-  template = file("${path.module}/resources/ecs/task_definition.json")
-  depends_on = [
-    null_resource.rds_endpoint
-  ]
 }
 
 


### PR DESCRIPTION
## Summary
- Replaced `data "template_file"` blocks with built-in `templatefile()` and `file()` functions in both module-1 and module-2
- Removes the dependency on `hashicorp/template` provider, which does not have a package for `darwin_arm64`

## Problem
Running `terraform init` on Apple Silicon (M1/M2/M3) Macs fails with:
```
Error: Incompatible provider version
Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your current platform, darwin_arm64.
```

## Fix
The `hashicorp/template` provider is deprecated. Terraform's built-in `templatefile()` function and `file()` function are drop-in replacements that require no external provider.

## Test plan
- [ ] `terraform init` succeeds on darwin_arm64
- [ ] `terraform plan` produces the same output as before